### PR TITLE
feat(): display recap of all released packages at the end

### DIFF
--- a/src/lib/multiSemanticRelease.ts
+++ b/src/lib/multiSemanticRelease.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'path'
-import semanticRelease, { Options } from 'semantic-release'
+import semanticRelease, { Options, Result } from 'semantic-release'
 import { uniq } from 'lodash-es'
 import { WriteStream } from 'tty'
 import batchingToposort from 'batching-toposort'
@@ -111,12 +111,19 @@ export default async function multiSemanticRelease(
       await Promise.all(promises)
     }
 
-    const released = packages.filter(pkg => pkg.result).length
+    const releasePackages = packages.filter(pkg => pkg.result)
 
     // Return packages list.
     logger.complete(
-      `Released ${released} of ${packages.length} packages, semantically!`,
+      `Released ${releasePackages.length} of ${packages.length} packages, semantically!`,
     )
+    releasePackages.forEach(pkg => {
+      logger.complete(
+        `Released package ${
+          (pkg.result as Exclude<Result, false>).nextRelease.gitTag
+        }`,
+      )
+    })
     return packages
   } catch (err: any) {
     if (err.message?.startsWith('Cycle(s) detected;')) {

--- a/src/test/lib/multiSemanticRelease.test.ts
+++ b/src/test/lib/multiSemanticRelease.test.ts
@@ -64,6 +64,10 @@ describe('multiSemanticRelease()', () => {
     expect(out).toMatch('Created tag msr-test-c@1.0.0')
     expect(out).toMatch('Created tag msr-test-d@1.0.0')
     expect(out).toMatch('Released 4 of 4 packages, semantically!')
+    expect(out).toMatch('Released package msr-test-a@1.0.0')
+    expect(out).toMatch('Released package msr-test-b@1.0.0')
+    expect(out).toMatch('Released package msr-test-c@1.0.0')
+    expect(out).toMatch('Released package msr-test-d@1.0.0')
 
     // A.
     expect(result[0].name).toBe('msr-test-a')


### PR DESCRIPTION
Here's a small suggestion on adding an extra log allowing to have a recap of deployed

this will be precious for the subscriptions repo where we have 13 packages and it's hard to find which package has been released